### PR TITLE
screenkey: unset XMODIFIERS to avoid XOpenIM err

### DIFF
--- a/pkgs/applications/video/screenkey/default.nix
+++ b/pkgs/applications/video/screenkey/default.nix
@@ -47,6 +47,10 @@ buildPythonApplication rec {
     pygtk
   ];
 
+  preFixup = ''
+    gappsWrapperArgs+=(--unset XMODIFIERS)
+  '';
+
   # screenkey does not have any tests
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change

I know you're tired. So instead of asking you to do it I figured I'll propose a PR. Perhaps it's not as clean as it should be... In that case I'll just keep track of the status on GitHub and submit fixes until we get it right.

point is...  on my setup this fails with 

```
DEBUG:Screenkey:Options loaded.
DEBUG:Screenkey:Restarting LabelManager.
DEBUG:Screenkey:Thread started.
DEBUG:Screenkey:Restarting LabelManager.
Exception in thread Thread-1:
Traceback (most recent call last):
  File /nix/store/i3bx1iw2d0i3vh9sa1nf92ynlrw324w8-python-2.7.14/lib/python2.7/threading.py, line 801, in __bootstrap_inner
    self.run()
  File /nix/store/r7dqmjgcp6y72939rwsm0x941k7kd78y-screenkey-0.9/lib/python2.7/site-packages/Screenkey/keylistener.py, line 245, in run
    raise Exception(Cannot initialize input method)
Exception: Cannot initialize input method

zsh: terminated  ./result/bin/screenkey -d
```

I resolved this in my old PR (#34898) by unsetting `XMODIFIERS`. Using `wrapProgram`, I kind of know how to do this the "right" way, but with `wrapGAppsHook` I figured appending to `gappsWrapperArgs` would suffice even though there aren't any examples of unsetting variables this way in the entire nixpkgs repository so far... or my grep was lousy. So I don't really know if this is a clean way of doing this. I already mentioned this PR in #34167 so I'm counting on feedback soon enough.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

